### PR TITLE
(fix) Fixed error checking logic, after pcall

### DIFF
--- a/lib/resty/openssl/version.lua
+++ b/lib/resty/openssl/version.lua
@@ -54,8 +54,9 @@ if not ok then
   end)
 end
 
-if not version_num or version_num < 0x10000000 then
-  error(string.format("OpenSSL version %x is not supported", version_num or 0))
+-- since pcall can return string in the case of error it must be handled appropriately
+if type(version_num) == 'string' or not version_num or version_num < 0x10000000 then
+  error(string.format("OpenSSL version %s is not supported", tostring(version_num or 0)))
 end
 
 if version_num >= 0x30000000 then


### PR DESCRIPTION
Since pcall can return as the second argument string,  version_num variable can have a string value and checking it against a  number will throw error 