### PR TITLE
(fix)Fixed error checking logic, after pcall

### DIFF
--- a/lib/resty/openssl/version.lua
+++ b/lib/resty/openssl/version.lua
@@ -54,8 +54,13 @@ if not ok then
   end)
 end
 
-if not version_num or version_num < 0x10000000 then
-  error(string.format("OpenSSL version %x is not supported", version_num or 0))
+
+if not ok then
+  error(string.format("OpenSSL has encountered an error: %s", tostring(version_num)))
+elseif type(version_num) == 'number' and version_num < 0x10000000 then
+  error(string.format("OpenSSL version %s is not supported", tostring(version_num or 0)))
+elseif not version_num then
+  error("Can not get OpenSSL version")
 end
 
 if version_num >= 0x30000000 then

--- a/lib/resty/openssl/version.lua
+++ b/lib/resty/openssl/version.lua
@@ -39,8 +39,7 @@ end)
 
 if not ok then
   -- 1.0.x
-  local _
-  _, version_num = pcall(function()
+  ok, version_num = pcall(function()
     local num = C.SSLeay()
     version_func = C.SSLeay_version
     types_table = {


### PR DESCRIPTION
Since pcall can return as the second argument string, version_num variable can have a string value and in the case it must be handled appropriately