### PR TITLE
(chore) free memory using asn1_time_free when asn1_time_set is used

### DIFF
--- a/lib/resty/openssl/include/asn1.lua
+++ b/lib/resty/openssl/include/asn1.lua
@@ -43,6 +43,7 @@ declare_asn1_functions("ASN1_INTEGER")
 declare_asn1_functions("ASN1_OBJECT")
 declare_asn1_functions("ASN1_STRING")
 declare_asn1_functions("ASN1_ENUMERATED")
+declare_asn1_functions("ASN1_TIME")
 
 local OPENSSL_10 = require("resty.openssl.version").OPENSSL_10
 local OPENSSL_11_OR_LATER = require("resty.openssl.version").OPENSSL_11_OR_LATER

--- a/lib/resty/openssl/x509/revoked.lua
+++ b/lib/resty/openssl/x509/revoked.lua
@@ -56,7 +56,7 @@ function _M.new(sn, time, reason)
   if time == nil then
     return nil, format_error("x509.revoked.new: ASN1_TIME_set()")
   end
-  ffi_gc(time, C.ASN1_STRING_free)
+  ffi_gc(time, C.ASN1_TIME_free)
 
   if C.X509_REVOKED_set_revocationDate(ctx, time) == 0 then
     return nil, format_error("x509.revoked.new: X509_REVOKED_set_revocationDate()")


### PR DESCRIPTION
For consistency using time_free instead of string_free