### PR TITLE
(fix) fixes get digest check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ install: all
 	$(INSTALL) lib/resty/openssl/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty/openssl/
 	
 test: all
-	PATH=$(OPENRESTY_PREFIX)/nginx/sbin:$$PATH prove -I../test-nginx/lib -r t/openssl/digest.t
+	PATH=$(OPENRESTY_PREFIX)/nginx/sbin:$$PATH prove -I../test-nginx/lib -r t
 
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ install: all
 	$(INSTALL) lib/resty/openssl/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty/openssl/
 	
 test: all
-	PATH=$(OPENRESTY_PREFIX)/nginx/sbin:$$PATH prove -I../test-nginx/lib -r t
+	PATH=$(OPENRESTY_PREFIX)/nginx/sbin:$$PATH prove -I../test-nginx/lib -r t/openssl/digest.t
 
 

--- a/lib/resty/openssl/digest.lua
+++ b/lib/resty/openssl/digest.lua
@@ -32,7 +32,7 @@ function _M.new(typ)
     dtyp = C.EVP_md_null()
   else
     dtyp = C.EVP_get_digestbyname(typ or 'sha1')
-    if dtyp == nil then
+    if dtyp == ffi.NULL  then
       return nil, string.format("digest.new: invalid digest type \"%s\"", typ)
     end
   end

--- a/t/openssl/digest.t
+++ b/t/openssl/digest.t
@@ -115,3 +115,19 @@ __DATA__
 "
 --- no_error_log
 [error]
+
+=== TEST 6: Check that wrong digest name returns error
+--- http_config eval: $::HttpConfig
+--- config
+    location =/t {
+        content_by_lua_block {
+            local _, err = require("resty.openssl.digest").new("test")
+            ngx.say(err)
+        }
+    }
+--- request
+    GET /t
+--- response_body eval
+"digest.new: invalid digest type \"test\"\x{0a}"
+--- no_error_log
+[error]


### PR DESCRIPTION
C.EVP_get_digestbyname returns ffi.NULL if digest is invalid, therfoe it should be checked with ffi.NULL, but not nil