### PR TITLE
fix(*) redefine callback functions to a style FFI will not overflow 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3233,7 +3233,7 @@ Wraps the `SSL_CTX*` instance from current downstream request.
 
 [Back to TOC](#table-of-contents)
 
-### ssl_ctx.from_request
+### ssl_ctx.from_socket
 
 **syntax**: *sess, err = ssl_ctx.from_socket(sock)*
 

--- a/lib/resty/openssl/include/pem.lua
+++ b/lib/resty/openssl/include/pem.lua
@@ -4,33 +4,34 @@ local ffi = require "ffi"
 require "resty.openssl.include.ossl_typ"
 
 ffi.cdef [[
-  typedef int pem_password_cb (char *buf, int size, int rwflag, void *userdata);
+  // all pem_password_cb* has been modified to pem_password_cb to avoid a table overflow issue
+  typedef int (*pem_password_cb)(char *buf, int size, int rwflag, void *userdata);
   EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x,
   // the following signature has been modified to avoid ffi.cast
-    pem_password_cb *cb, const char *u);
+    pem_password_cb cb, const char *u);
   //  pem_password_cb *cb, void *u);
   EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x,
   // the following signature has been modified to avoid ffi.cast
-    pem_password_cb *cb, const char *u);
+    pem_password_cb cb, const char *u);
   //  pem_password_cb *cb, void *u);
   int PEM_write_bio_PrivateKey(BIO *bp, EVP_PKEY *x, const EVP_CIPHER *enc,
     unsigned char *kstr, int klen,
-    pem_password_cb *cb, void *u);
+    pem_password_cb cb, void *u);
   int PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x);
 
-  X509_REQ *PEM_read_bio_X509_REQ(BIO *bp, X509_REQ **x, pem_password_cb *cb, void *u);
+  X509_REQ *PEM_read_bio_X509_REQ(BIO *bp, X509_REQ **x, pem_password_cb cb, void *u);
   int PEM_write_bio_X509_REQ(BIO *bp, X509_REQ *x);
 
-  X509_CRL *PEM_read_bio_X509_CRL(BIO *bp, X509_CRL **x, pem_password_cb *cb, void *u);
+  X509_CRL *PEM_read_bio_X509_CRL(BIO *bp, X509_CRL **x, pem_password_cb cb, void *u);
   int PEM_write_bio_X509_CRL(BIO *bp, X509_CRL *x);
 
-  X509 *PEM_read_bio_X509(BIO *bp, X509 **x, pem_password_cb *cb, void *u);
+  X509 *PEM_read_bio_X509(BIO *bp, X509 **x, pem_password_cb cb, void *u);
   int PEM_write_bio_X509(BIO *bp, X509 *x);
 
-  DH *PEM_read_bio_DHparams(BIO *bp, DH **x, pem_password_cb *cb, void *u);
+  DH *PEM_read_bio_DHparams(BIO *bp, DH **x, pem_password_cb cb, void *u);
   int PEM_write_bio_DHparams(BIO *bp, DH *x);
 
-  EC_GROUP *PEM_read_bio_ECPKParameters(BIO *bp, EC_GROUP **x, pem_password_cb *cb, void *u);
+  EC_GROUP *PEM_read_bio_ECPKParameters(BIO *bp, EC_GROUP **x, pem_password_cb cb, void *u);
   int PEM_write_bio_ECPKParameters(BIO *bp, const EC_GROUP *x);
 
 ]]

--- a/lib/resty/openssl/include/ssl.lua
+++ b/lib/resty/openssl/include/ssl.lua
@@ -52,7 +52,7 @@ ffi.cdef [[
   /*STACK_OF(SSL_CIPHER)*/ OPENSSL_STACK *SSL_CTX_get_ciphers(const SSL_CTX *ctx);
   OPENSSL_STACK *SSL_get_peer_cert_chain(const SSL *ssl);
 
-  typedef int verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx);
+  typedef int (*verify_callback)(int preverify_ok, X509_STORE_CTX *x509_ctx);
   void SSL_set_verify(SSL *s, int mode,
                      int (*verify_callback)(int, X509_STORE_CTX *));
 

--- a/lib/resty/openssl/pkey.lua
+++ b/lib/resty/openssl/pkey.lua
@@ -88,7 +88,7 @@ local function load_pem_der(txt, opts, funcs)
           end
           arg = { null, nil, passphrase }
         elseif opts.passphrase_cb then
-          passphrase_cb = ffi_cast("pem_password_cb*", function(buf, size)
+          passphrase_cb = ffi_cast("pem_password_cb", function(buf, size)
             local p = opts.passphrase_cb()
             local len = #p -- 1 byte for \0
             if len > size then

--- a/lib/resty/openssl/ssl.lua
+++ b/lib/resty/openssl/ssl.lua
@@ -216,7 +216,7 @@ function _M:get_timeout()
   return tonumber(C.SSL_SESSION_get_timeout(session))
 end
 
-local ssl_verify_default_cb = ffi_cast("verify_callback*", function()
+local ssl_verify_default_cb = ffi_cast("verify_callback", function()
   return 1
 end)
 
@@ -226,7 +226,7 @@ function _M:set_verify(mode, cb)
   end
 
   if cb then
-    cb = ffi_cast("verify_callback*", cb)
+    cb = ffi_cast("verify_callback", cb)
     self._verify_cb = cb
   end
 


### PR DESCRIPTION
Though in C function pointers are flexible, FFI seems to only accept
certain combination of usage:

```lua
-- as signature
void (*cb)(...);
-- when used
void consumer(cb c);
```

Some combination will result in FFI parser error, one will result in
FFI doing implict magic and result in overflow:

```lua
local ffi = require("ffi")
ffi.cdef[[
typedef int cb();
]]
for i=0, 60000 do
    local pok, pp = pcall(ffi.cast, "cb*", function() end)
    if not pok then
        print(i, ", ", pp)
        break
    end
    if pp then pp:free() end
end
```