### PR TITLE
fix(pkey) avoid callbacks overflow when setting passphrase_cb

### DIFF
--- a/lib/resty/openssl/pkey.lua
+++ b/lib/resty/openssl/pkey.lua
@@ -88,7 +88,7 @@ local function load_pem_der(txt, opts, funcs)
           end
           arg = { null, nil, passphrase }
         elseif opts.passphrase_cb then
-          passphrase_cb = ffi_cast("pem_password_cb", function(buf, size)
+          passphrase_cb = passphrase_cb or ffi_cast("pem_password_cb", function(buf, size)
             local p = opts.passphrase_cb()
             local len = #p -- 1 byte for \0
             if len > size then


### PR DESCRIPTION
During the funcs iteration of load_pem_der, it was possible that
the passphrase_cb was creating a new C callback more than once
without freeing the previous one.

This issue was reported by users doing many Kong config updates,
with a lot of keys.