### PR TITLE
fix(x509.*) use SHA256 as default sign digest in BoringSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Table of Contents
     + [pkey:set_parameters](#pkeyset_parameters)
     + [pkey:is_private](#pkeyis_private)
     + [pkey:get_key_type](#pkeyget_key_type)
+    + [pkey:get_default_digest_type](#pkeyget_default_digest_type)
     + [pkey:sign](#pkeysign)
     + [pkey:verify](#pkeyverify)
     + [pkey:encrypt](#pkeyencrypt)
@@ -942,6 +943,22 @@ local pkey, err = require("resty.openssl.pkey").new({type="X448"})
 
 ngx.say(require("cjson").encode(pkey:get_key_type()))
 -- outputs '{"ln":"X448","nid":1035,"sn":"X448","id":"1.3.101.111"}'
+```
+
+[Back to TOC](#table-of-contents)
+
+### pkey:get_default_digest_type
+
+**syntax**: *obj, err = pk:get_default_digest_type()*
+
+Returns a ASN1_OBJECT of key type of the private key as a table. An additional field `mandatory` is also
+returned in the table, if `mandatory` is true then other digests can not be used.
+
+```lua
+local pkey, err = require("resty.openssl.pkey").new()
+
+ngx.say(require("cjson").encode(pkey:get_default_digest_type()))
+-- outputs '{"ln":"sha256","nid":672,"id":"2.16.840.1.101.3.4.2.1","mandatory":false,"sn":"SHA256"}'
 ```
 
 [Back to TOC](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -2442,7 +2442,7 @@ Sign the certificate using the private key specified by `pkey`, which must be a
 parameter to set digest method, whichmust be a [resty.openssl.digest](#restyopenssldigest) instance.
 Returns a boolean indicating if signing is successful and error if any.
 
-In BoringSSL, `digest` must be set as no default digest is set.
+In BoringSSL when `digest` is not set it's fallback to `SHA256`.
 
 [Back to TOC](#table-of-contents)
 
@@ -2646,7 +2646,7 @@ Sign the certificate request using the private key specified by `pkey`, which mu
 parameter to set digest method, whichmust be a [resty.openssl.digest](#restyopenssldigest) instance.
 Returns a boolean indicating if signing is successful and error if any.
 
-In BoringSSL, `digest` must be set as no default digest is set.
+In BoringSSL when `digest` is not set it's fallback to `SHA256`.
 
 [Back to TOC](#table-of-contents)
 
@@ -2835,7 +2835,7 @@ Sign the CRL using the private key specified by `pkey`, which must be a
 parameter to set digest method, whichmust be a [resty.openssl.digest](#restyopenssldigest) instance.
 Returns a boolean indicating if signing is successful and error if any.
 
-In BoringSSL, `digest` must be set as no default digest is set.
+In BoringSSL when `digest` is not set it's fallback to `SHA256`.
 
 [Back to TOC](#table-of-contents)
 

--- a/examples/csr.lua
+++ b/examples/csr.lua
@@ -54,7 +54,7 @@ end
 -- create a EC key
 local pkey, err = require("resty.openssl.pkey").new({
   type = 'EC',
-  curve = 'prime192v1',
+  curve = 'prime256v1',
 })
 if err then
   error(err)

--- a/lib/resty/openssl/x509/crl.lua
+++ b/lib/resty/openssl/x509/crl.lua
@@ -16,6 +16,7 @@ local format_error = require("resty.openssl.err").format_error
 local version = require("resty.openssl.version")
 local OPENSSL_10 = version.OPENSSL_10
 local OPENSSL_11_OR_LATER = version.OPENSSL_11_OR_LATER
+local BORINGSSL = version.BORINGSSL
 local BORINGSSL_110 = version.BORINGSSL_110 -- used in boringssl-fips-20190808
 
 local accessors = {}
@@ -194,16 +195,20 @@ function _M:sign(pkey, digest)
     return false, "x509.crl:sign: expect a pkey instance at #1"
   end
 
+  local digest_algo
   if digest then
     if not digest_lib.istype(digest) then
       return false, "x509.crl:sign: expect a digest instance at #2"
     elseif not digest.algo then
       return false, "x509.crl:sign: expect a digest instance to have algo member"
     end
+    digest_algo = digest.algo
+  elseif BORINGSSL then
+    digest_algo = C.EVP_get_digestbyname('sha256')
   end
 
   -- returns size of signature if success
-  if C.X509_CRL_sign(self.ctx, pkey.ctx, digest and digest.algo) == 0 then
+  if C.X509_CRL_sign(self.ctx, pkey.ctx, digest_algo) == 0 then
     return false, format_error("x509.crl:sign")
   end
 

--- a/lib/resty/openssl/x509/csr.lua
+++ b/lib/resty/openssl/x509/csr.lua
@@ -20,6 +20,7 @@ local format_error = require("resty.openssl.err").format_error
 local version = require("resty.openssl.version")
 local OPENSSL_10 = version.OPENSSL_10
 local OPENSSL_11_OR_LATER = version.OPENSSL_11_OR_LATER
+local BORINGSSL = version.BORINGSSL
 local BORINGSSL_110 = version.BORINGSSL_110 -- used in boringssl-fips-20190808
 
 local accessors = {}
@@ -323,16 +324,20 @@ function _M:sign(pkey, digest)
     return false, "x509.csr:sign: expect a pkey instance at #1"
   end
 
+  local digest_algo
   if digest then
     if not digest_lib.istype(digest) then
       return false, "x509.csr:sign: expect a digest instance at #2"
     elseif not digest.algo then
       return false, "x509.csr:sign: expect a digest instance to have algo member"
     end
+    digest_algo = digest.algo
+  elseif BORINGSSL then
+    digest_algo = C.EVP_get_digestbyname('sha256')
   end
 
   -- returns size of signature if success
-  if C.X509_REQ_sign(self.ctx, pkey.ctx, digest and digest.algo) == 0 then
+  if C.X509_REQ_sign(self.ctx, pkey.ctx, digest_algo) == 0 then
     return false, format_error("x509.csr:sign")
   end
 

--- a/scripts/templates/x509_functions.j2
+++ b/scripts/templates/x509_functions.j2
@@ -5,16 +5,20 @@ function _M:sign(pkey, digest)
     return false, "{{modname}}:sign: expect a pkey instance at #1"
   end
 
+  local digest_algo
   if digest then
     if not digest_lib.istype(digest) then
       return false, "{{modname}}:sign: expect a digest instance at #2"
-    elseif not digest.dtyp then
-      return false, "{{modname}}:sign: expect a digest instance to have dtyp member"
+    elseif not digest.algo then
+      return false, "{{modname}}:sign: expect a digest instance to have algo member"
     end
+    digest_algo = digest.algo
+  elseif BORINGSSL then
+    digest_algo = C.EVP_get_digestbyname('sha256')
   end
 
   -- returns size of signature if success
-  if C.{{ module.type }}_sign(self.ctx, pkey.ctx, digest and digest.dtyp) == 0 then
+  if C.{{ module.type }}_sign(self.ctx, pkey.ctx, digest_algo) == 0 then
     return false, format_error("{{ modname }}:sign")
   end
 

--- a/t/openssl/pkey.t
+++ b/t/openssl/pkey.t
@@ -1202,3 +1202,26 @@ default
 "
 --- no_error_log
 [error]
+
+=== TEST 37: Get default digest type
+--- http_config eval: $::HttpConfig
+--- config
+    location =/t {
+        content_by_lua_block {
+            if require("resty.openssl.version").BORINGSSL then
+                ngx.say('BROKEN sha256 BROKEN')
+                ngx.exit(0)
+            end
+
+            local pkey = require("resty.openssl.pkey")
+            local p = myassert(pkey.new({ type = "EC" }))
+            local algo = myassert(p:get_default_digest_type())
+            ngx.say(require("cjson").encode(algo))
+        }
+    }
+--- request
+    GET /t
+--- response_body_like
+.+sha256.+
+--- no_error_log
+[error]


### PR DESCRIPTION
Fix #42 