### PR TITLE
perf(*) reuse cdata to improve performance

### DIFF
--- a/lib/resty/openssl/auxiliary/ctypes.lua
+++ b/lib/resty/openssl/auxiliary/ctypes.lua
@@ -22,6 +22,7 @@ return {
     null = ffi.new("void *"), -- hack wher ngx.null is not available
 
     uchar_array = ffi.typeof("unsigned char[?]"),
+    uchar_ptr = ffi.typeof("unsigned char*"),
 
     SIZE_MAX = math.pow(2, 64), -- nginx set _FILE_OFFSET_BITS to 64
 }

--- a/lib/resty/openssl/hmac.lua
+++ b/lib/resty/openssl/hmac.lua
@@ -63,19 +63,19 @@ function _M:update(...)
   return true, nil
 end
 
+local result_length = ctypes.ptr_of_uint()
+
 function _M:final(s)
   if s then
-    local _, err = self:update(s)
-    if err then
-      return nil, err
+    if C.HMAC_Update(self.ctx, s, #s) ~= 1 then
+      return false, format_error("hmac:final")
     end
   end
 
-  local length = ctypes.ptr_of_uint()
-  if C.HMAC_Final(self.ctx, self.buf, length) ~= 1 then
+  if C.HMAC_Final(self.ctx, self.buf, result_length) ~= 1 then
     return nil, format_error("hmac:final: HMAC_Final")
   end
-  return ffi_str(self.buf, length[0])
+  return ffi_str(self.buf, result_length[0])
 end
 
 function _M:reset()

--- a/lib/resty/openssl/kdf.lua
+++ b/lib/resty/openssl/kdf.lua
@@ -130,6 +130,8 @@ local options_schema = {
   scrypt_p      = { TYPE_NUMBER, nil, NID_id_scrypt },
 }
 
+local outlen = ctypes.ptr_of_uint64()
+
 function _M.derive(options)
   local typ = options.type
   if not typ then
@@ -217,7 +219,7 @@ function _M.derive(options)
   -- end legacay low level routines
 
   -- begin EVP_PKEY_derive routines
-  local outlen = ctypes.ptr_of_uint64(options.outlen)
+  outlen[0] = options.outlen
 
   local ctx = C.EVP_PKEY_CTX_new_id(typ, nil)
   if ctx == nil then

--- a/lib/resty/openssl/rand.lua
+++ b/lib/resty/openssl/rand.lua
@@ -8,6 +8,8 @@ local ctypes = require "resty.openssl.auxiliary.ctypes"
 local format_error = require("resty.openssl.err").format_error
 local OPENSSL_30 = require("resty.openssl.version").OPENSSL_30
 
+local buf
+local buf_size = 0
 local function bytes(length, private, strength)
   if type(length) ~= "number" then
     return nil, "rand.bytes: expect a number at #1"
@@ -16,7 +18,13 @@ local function bytes(length, private, strength)
   end
   -- generally we don't need manually reseed rng
   -- https://www.openssl.org/docs/man1.1.1/man3/RAND_seed.html
-  local buf = ctypes.uchar_array(length)
+
+  -- initialize or resize buffer
+  if not buf or buf_size < length then
+    buf = ctypes.uchar_array(length)
+    buf_size = length
+  end
+
   local code
   if OPENSSL_30 then
     if private then


### PR DESCRIPTION
Although still slower than ngx.md5_bin, we are around 15% faster than previous self.

```
resty.openssl.digest(md5) took 1870 ms
resty.openssl.digest(md5,old) took 2159 ms
resty.md5 took 2423 ms
ngx.md5_bin took 1341 ms

resty.openssl.cipher(aes,encrypt) took 598 ms
resty.openssl.cipher(aes,encrypt,old) took 818ms
resty.aes took 1891 ms
```

Because EVP contextes are reused, we are still way faster than resty.string implementation.

<details><summary> digest </summary>

```lua
local md5 = ngx.md5_bin
local resty_md5 = require "resty.md5"

local function runperf()
  local digest = require "resty.openssl.digest"
  local update_time = ngx.update_time
  local now = ngx.now

  local md5_bin = digest.new("md5")


  local m = "my:cache:key:b864ded6-f344-49f7-b999-dd9f6aaaad7f"

  update_time()
  local s = now()*1000
  for _i= 1, 10000000 do
    md5_bin:final(m)
    md5_bin:reset()
  end
  update_time()
  local e = now()*1000

  ngx.log(ngx.ERR, "resty.openssl.digest(md5) took ", e - s, " ms")

  update_time()
  local s = now()*1000
  for _i= 1, 10000000 do
      local md5 = resty_md5:new()
      md5:update(m)
      md5:final()
  end
  update_time()
  local e = now()*1000

  ngx.log(ngx.ERR, "resty.md5 took ", e - s, " ms")

  update_time()
  s = now()*1000
  for _i= 1, 10000000 do
    ngx.md5_bin(m)
  end
  update_time()
  e = now()*1000

  ngx.log(ngx.ERR, "ngx.md5 took ", e - s, " ms")

end
runperf()
```
</details>

<details><summary> cipher </summary>

```lua
local aes = require "resty.aes"

local function runperf()
  local cipher = require "resty.openssl.cipher"
  local update_time = ngx.update_time
  local now = ngx.now

  local aes_128 = cipher.new("aes-128-cbc")
  local key = string.rep("0", 16)
  local iv = string.rep("0", 16)

  local m = "my:cache:key:b864ded6-f344-49f7-b999-dd9f6aaaad7f"

  local d
  update_time()
  local s = now()*1000
  for _i= 1, 1000000 do
      aes_128:init(key, iv, {
          is_encrypt = true,
      })
      d = aes_128:final(m)
  end
  update_time()
  local e = now()*1000

  ngx.log(ngx.ERR, "resty.openssl.cipher(aes,encrypt) ", e - s, " ms")
  print(d)

  local _hash = { iv = iv }
  update_time()
  local s = now()*1000
  for _i= 1, 1000000 do
      local aes_128_cbc_md5 = aes:new(key, nil, nil, _hash )
      d = aes_128_cbc_md5:encrypt(m)
  end
  update_time()
  local e = now()*1000

  ngx.log(ngx.ERR, "resty.aes(encrypt) took ", e - s, " ms")
  print(d)

  update_time()
  local s = now()*1000
  for _i= 1, 1000000 do
    d = aes_128:encrypt(key, iv, m)
  end
  update_time()
  local e = now()*1000

  ngx.log(ngx.ERR, "resty.openssl.digest oneshot took ", e - s, " ms")
  print(d)
end
runperf()
```

</details>
