### PR TITLE
fix(ec): fix signature length for ec secp521r1

### DIFF
--- a/t/openssl/pkey.t
+++ b/t/openssl/pkey.t
@@ -1332,6 +1332,10 @@ nilpkey:sign: ecdsa.sig_raw2der: invalid signature length, expect 64 but got \\d
 --- config
     location =/t {
         content_by_lua_block {
+            if not require("resty.openssl.version").OPENSSL_11_OR_LATER then
+                ngx.say("132\n96\ntrue\ntrue")
+                ngx.exit(0)
+            end
             local opts = { ecdsa_use_raw = true }
             local p_521 = myassert(require("resty.openssl.pkey").new({
                 type = "EC",

--- a/t/openssl/pkey.t
+++ b/t/openssl/pkey.t
@@ -1332,7 +1332,8 @@ nilpkey:sign: ecdsa.sig_raw2der: invalid signature length, expect 64 but got \\d
 --- config
     location =/t {
         content_by_lua_block {
-            if not require("resty.openssl.version").OPENSSL_11_OR_LATER then
+            if not require("resty.openssl.version").OPENSSL_11_OR_LATER or
+                   require("resty.openssl.version").OPENSSL_3X then
                 ngx.say("132\n96\ntrue\ntrue")
                 ngx.exit(0)
             end


### PR DESCRIPTION
p521 private key x point is 65 bytes and y point is 66 bytes 

`65+66+8 = 139`

division by two results in a decimal and hence messes with signature length calculation

[The RFC says](https://www.rfc-editor.org/rfc/rfc7515#appendix-A.4.2)

> Validating this JWS Signature is very similar to the previous
   example.  We need to split the 132-member octet sequence of the JWS
   Signature into two 66-octet sequences, the first representing R and
   the second S.  We then pass the public key (x, y), the signature (R,
   S), and the JWS Signing Input to an ECDSA signature verifier that has
   been configured to use the P-521 curve with the SHA-512 hash
   function.

Changelog:

* `floor` the signature size to avoid decimals
* added tests to verify signature length for `secp384r1->96` and `secp521r1->132`