### PR TITLE
fix(pkey): clear error stack when verification fails

### DIFF
--- a/lib/resty/openssl/pkey.lua
+++ b/lib/resty/openssl/pkey.lua
@@ -868,7 +868,7 @@ function _M:verify(signature, digest, md_alg, padding, opts)
   end
 
   if code == 0 then
-    return false, nil
+    return false, format_error("pkey:verify")
   elseif code == 1 then
     return true, nil
   end


### PR DESCRIPTION
Otherwise, Nginx will print such an alert log message when establishing a new ssl connection.

`ignoring stale global SSL error (SSL: error:04091068:rsa routines:int_rsa_verify:bad signature)`

[FTI-5324](https://konghq.atlassian.net/browse/FTI-5324)