### PR TITLE
fixed use-after-free in bn.lua.

### DIFF
--- a/lib/resty/openssl/bn.lua
+++ b/lib/resty/openssl/bn.lua
@@ -80,7 +80,10 @@ function _M.new(some, base)
   local ctx = C.BN_new()
   ffi_gc(ctx, C.BN_free)
 
-  local ctx, err = set_bn(ctx, some, base)
+  -- local ctx, err = set_bn(ctx, some, base)
+  -- The above expression set ctx to a new cdata return by
+  -- set_bn, the origin cdata would be GC at any time.
+  local _, err = set_bn(ctx, some, base)
   if err then
     return nil, "bn.new: " .. err
   end


### PR DESCRIPTION
READ of size 4 at 0x60300004fba8 thread T0
    #0 0x7ffff6d96fb4 in BN_get_word crypto/bn/bn_lib.c:411
    #1 0x555555ca9d98  (/usr/local/openresty-plus-asan/nginx/sbin/nginx+0x755d98)
    #2 0x555555d7149f in lj_ccall_func /usr/src/debug/openresty-plus-1.19.9.1.65/build/LuaJIT-plus-2.1-20240710/src/lj_ccall.c:1402
    #3 0x555555ca35b7 in lj_cf_ffi_meta___call /usr/src/debug/openresty-plus-1.19.9.1.65/build/LuaJIT-plus-2.1-20240710/src/lib_ffi.c:230
    #4 0x555555ca7773  (/usr/local/openresty-plus-asan/nginx/sbin/nginx+0x753773)
    #5 0x55555599e140 in ngx_http_lua_run_thread ../ngx_lua-0.10.26.8/src/ngx_http_lua_util.c:1190
    #6 0x5555559a9d21 in ngx_http_lua_content_by_chunk ../ngx_lua-0.10.26.8/src/ngx_http_lua_contentby.c:124
    #7 0x55555575d41d in ngx_http_core_content_phase src/http/ngx_http_core_module.c:1269
    #8 0x555555748024 in ngx_http_core_run_phases src/http/ngx_http_core_module.c:885
    #9 0x55555577348d in ngx_http_process_request src/http/ngx_http_request.c:2130
    #10 0x5555557749a6 in ngx_http_process_request_headers src/http/ngx_http_request.c:1529
    #11 0x5555557758c4 in ngx_http_process_request_line src/http/ngx_http_request.c:1196
    #12 0x55555570fb1c in ngx_epoll_process_events src/event/modules/ngx_epoll_module.c:968
    #13 0x5555556e5706 in ngx_process_events_and_timers src/event/ngx_event.c:262
    #14 0x55555570b323 in ngx_single_process_cycle src/os/unix/ngx_process_cycle.c:338
    #15 0x555555660ef4 in main src/core/nginx.c:403
    #16 0x7ffff683feaf in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #17 0x7ffff683ff5f in __libc_start_main_impl ../csu/libc-start.c:389
    #18 0x5555556648f4 in _start (/usr/local/openresty-plus-asan/nginx/sbin/nginx+0x1108f4)

0x60300004fba8 is located 8 bytes inside of 24-byte region [0x60300004fba0,0x60300004fbb8) freed by thread T0 here:
    #0 0x7ffff74b46b7 in free (/lib64/libasan.so.6+0xb46b7)
    #1 0x7ffff6ea66e7 in CRYPTO_free crypto/mem.c:312
    #2 0x7ffff6d9810e in BN_free crypto/bn/bn_lib.c:231
    #3 0x555555ca9d98  (/usr/local/openresty-plus-asan/nginx/sbin/nginx+0x755d98)
    #4 0x555555d7149f in lj_ccall_func /usr/src/debug/openresty-plus-1.19.9.1.65/build/LuaJIT-plus-2.1-20240710/src/lj_ccall.c:1402
    #5 0x555555ca35b7 in lj_cf_ffi_meta___call /usr/src/debug/openresty-plus-1.19.9.1.65/build/LuaJIT-plus-2.1-20240710/src/lib_ffi.c:230
    #6 0x555555ca7773  (/usr/local/openresty-plus-asan/nginx/sbin/nginx+0x753773)

previously allocated by thread T0 here:
    #0 0x7ffff74b4a07 in __interceptor_malloc (/lib64/libasan.so.6+0xb4a07)
    #1 0x7ffff6ea66bc in CRYPTO_malloc crypto/mem.c:222
    #2 0x7ffff6ea6807 in CRYPTO_zalloc crypto/mem.c:230
    #3 0x7ffff6d96c15 in BN_new crypto/bn/bn_lib.c:246
    #4 0x555555ca9d98  (/usr/local/openresty-plus-asan/nginx/sbin/nginx+0x755d98)
    #5 0x555555d7149f in lj_ccall_func /usr/src/debug/openresty-plus-1.19.9.1.65/build/LuaJIT-plus-2.1-20240710/src/lj_ccall.c:1402
    #6 0x555555ca35b7 in lj_cf_ffi_meta___call /usr/src/debug/openresty-plus-1.19.9.1.65/build/LuaJIT-plus-2.1-20240710/src/lib_ffi.c:230
    #7 0x555555ca7773  (/usr/local/openresty-plus-asan/nginx/sbin/nginx+0x753773)