### PR TITLE
fix: pkey.new() failed, after compile pkey.lua to LuaJIT bytecode

### DIFF
--- a/lib/resty/openssl/pkey.lua
+++ b/lib/resty/openssl/pkey.lua
@@ -109,7 +109,7 @@ local function load_pem_der(txt, opts, funcs)
             C.ERR_clear_error()
             return nil, "passphrase must be a string"
           end
-          arg = { null, nil, passphrase }
+          arg = { null, null, passphrase }
         elseif opts.passphrase_cb then
           passphrase_cb = passphrase_cb or ffi_cast("pem_password_cb", function(buf, size)
             local p = opts.passphrase_cb()


### PR DESCRIPTION
Example code(test.lua)
```
local pem_private_key = [[
-----BEGIN ENCRYPTED PRIVATE KEY-----
MIIFLTBXBgkqhkiG9w0BBQ0wSjApBgkqhkiG9w0BBQwwHAQIGloALBPxu1UCAggA
MAwGCCqGSIb3DQIJBQAwHQYJYIZIAWUDBAEqBBD3qtUzpexPjJKfcQw0CFPoBIIE
0DQG1OnyqjvC5xiTiEA4hWOGrLYG08RkWi/7KmFSpn0S3jDTYr1mEWgktU+L2GJV
Lr4cnw9fcN+M33qFD008gIc+SRKazxj1Ap+x8qEWoB4T3AZyqAv3giH+fNN2YZ1T
htIh8PO4v6tLwZNU+cOS/b9+pIEj20R+jeIHh1oLudzbjATbRY3ANLtdKem0R1JW
3AFsi9k4iNyVfZTJHFwowfYQMYfSmhzhLG7+DpazqCJkPeu6TP3a/T+wyFS408aK
0z09F2G4KOosnv7qAn7hfCTl4ZGbY6TArZk9v43AOHP/yK33K/pUjVlZh0/Jvskb
4PAPHKWAWoIhbAI5h8V6aiR82p1c18KLE+Mt2CbPqLqbrpElfKqVad1YHa+3kxOn
Gin1c7o2sFhK/3aNStR4dVlgAOXaptjgvbb9dCeeoY/HtUN8dY2I9ldE5Mm0gA5V
WrQDsjIArSFimdcS16KF6WY6yBD/4HAKfjnZvhtWC7ytB1txwcnyK8sSwnLDUbU3
uUttIp3V2tRos51Tslw3XxdDHgPsByEYv8NLEb0VwcUp6TgDLn8ATVeV01WVX6uP
1J08G07jJvpgemMNLsJrICokhYZyzQGDTSsOGhGJkoNxwvOKJO5NTd1UaAQKySO1
cW/8o2QFFx3pJ2a/r2dF0m5MEeDNjZBb2Ybu8FHi31L2t8YJK4Rg9JuT1O2CZykm
RIKfzYawxQmkVQ7Y8X4QQLJ2QhAfXcPPvKV6lN71FnqFGaaI9GBwOV1f/FTfc93m
8i5PLBoKrHNIHfwpzLFgaggAMLTHHJGbgY4rVfIxaH/XPJmMOJbrgv/iH2BIXg/B
FezfEu3Rxfzgt0KLNeO/x5U6KNCFmZewgyRj/cz/tzjpT7XRBea53mvg5IXFiTya
21Nw8h7cWgsCrBGnDcG+xlEkth56olYYdP/F3r/XrMo62/r6S1zJdnovnPk+92lM
XNsq42NxQt4bBLl71XgLBz7TBJBrMFXDbfmOvp44VODTlun4A/EHtYjy/vdrbBjY
UtntZKbOjhzh9fkJ383uMJiLqRn876Cdv+oyfhvujK599EPp61IjmuKPjPbvxLIE
F0JAcXNEIHQUIjwwVZOockaOwonsHIZBdbcOQJYCeiPz77ls/raQGZt+A4h9yfu2
XgG37XyOE5QngzjYF5A98LF0dyrhtJB4rvRtByAlLrNeAL2KZJVeZrHq9RWQiehq
g4SfUxVC5DqBU5hg2xMFjJycpuL1YQJpl0LZyuw7GNPmOG4pnf+dbRfR5IDHg6eR
Zb8HtPWlDLHilekOhA9qYqvqRaEHurcstTUyaEZElQpFfgCgZG/N0F+7f5tWvZYs
+RJ5YmvjdQPcm3+PIrEQ5jjOHa6vbPGhUKm7S+hmakpUqmyDb2HdCEEdlEoegsCR
Kiz+/qVDzOzwAKrrXljuCcHoqvSJ30tvHGPY4guWTC8CjzgAuuUWnUojztw4pADk
/i0CThiBu27x1FoEfZ8axDnwtZumivAUe+3ji+C8G+oBOH5kVNqdoU8kp+qGTWkf
brfpHUIV0iczfGQ6xp9NdY3Xt/Z7FTO69rdU/Qtf7fMXcqDLE4mQ3b1tRWAh9CFI
F9keMQVAhvdUpPee8Z9EAHAdXH0TKgqdq6+ZRdfEnLXw
-----END ENCRYPTED PRIVATE KEY-----
]]

package.path = "./?.ljbc;./?/init.lua;" .. package.path
local pkey = require("resty.openssl.pkey")
local key, err = pkey.new(pem_private_key, {
    format = "PEM",
    type = "pr",
    passphrase = "12345678"
})
if not key then
    print("failed to load private key: " .. err)
end

print("pem private key:", key:to_PEM("PrivateKey"))

```

code works
```
$ resty test.lua 
pem private key:-----BEGIN PRIVATE KEY-----
MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDkVamejUOwGIql
nF04S6mojTz+7/RY2zyPDRCyLILQmwJ0+R2/QhKfwfRWt7sHYoJ3Go8RtGQx3vOv
c9wV2OnAwt+B20HAvfxSJIrWl9g23/AA5SXEjGQb61cuU8BJk1PMCQA5SIDYJOcH
hD36nfKQcOAbyKAa+3MJFUpJvGHAiAsUUheGrf5z6m15xlL5hQ1ioEwJEp3tCO56
uhUUBDC6PLrD5LUHGRkV77PJWL+soTuqLmQJPuWa48mnd3IEAcThoi5hdC/tLlF3
SIfWy8FrXMN6RcXHHR0B2XEItPNDGyYTBgFja0gsnjl4vdZrVHhq91566ttfAm6x
eE02UgYDAgMBAAECggEAFU2iui6+4naftOzeS6rPhPDMgJKdrw6hW01iQeViPRlB
RO2bJ2WAPFSJue+BbSJ1PqyFLacxc++zt6ptHcKzqG7mEIUG4Pc4y+cp5vSa0R/a
khLPD8PzcSFnbGSW+6ZZup8aXL3Ve5UR0wM1DyVeZLiLSDxTJ8FPDcllOXTwf9hk
Zrk4gg1422jMBwFD01K8cbqphYHGCCLaIHevFYRLKWGdyArA24dbcoG/yQVYp/Gf
oiZsmT0oP4PzMbvzP4J9Srhyo54h9wLmBL0NS/pQHtuTfZNShe59us+ATsOdV0Uv
xsDU+nO9IG80BdumrM4F+4SzWsKCX+D3Ie0/9NIJqQKBgQDzIU2mne1uCqgNMzAo
GzMYGpJlKP3ffVwdzMilEUgUdpcCD4XKvykkx/TMiD/EcN/4Q1Q4ED7cIe5NL3DK
CgNJ+XlFTk0/uvck8lTXOcf76ka9rr+7c2D71g4msfrgAbnCqY015zx3xp+/8b4G
eegmjPbH+SE5h9QEvMLUHM456QKBgQDwa90DTx6aTAIcoDaMerGCi2TfGg4wolb/
DjRx0tKF6PiiNwnSwq80+ZZonTjQeW9t/Z2JdNWFWg1iRdzKCZ8n2oA7PMc0TxFt
zmfkZwWRVHe/iODI0IAANWSgOB/0smFS1by3KtiFfWe7XJnXlfRwyOSwPICWn+wz
HR26fnqhCwKBgQDyZE+AP48I2IL2tgPa2FM2QreVNyrz940xAItBVltgW2Lt4P/o
RHEGhHugtm2ssUP5xVZfloK1APcN6LAwHY9t3tRyrkABu6rOIPNIqAijNMxWK7Rn
c/5K1PvCxEpzrgS++D8acHEukM2Plbl3x24VkRAwCkZ/jtVn67Dpu9Y2kQKBgCsA
f/V5j1W1xqLsHRWfVGSvHgmxlVwpjTnthn/dX35IH0CUa5Ng8wmcosRvapwPPFkG
BclyNka1xrMPH+CbO/Za5Jiz1EWM5ucnBfoaWyqVWx3NE7eXY22mHytxHnYb+cBh
LnHsnfGybn1aoMGotqH9rLnA+Jb4X7z8tjaHLNPlAoGAO4tIDhddhb9yr0JjeS+J
TyWnIUHTrAQlt5Ke7CSH5X+cVK8kU5Xn5oYL1U3ItwGA1Fx5FwJ8OBoI0anzbTbK
23t//DtT2mM/6snpEM9eA0TcTE5kG3chC5K24FZA2OU0t3EOfGyc4z93xjnjY1hL
Z07RBUWmecQcAy2AqQ+Rqyo=
-----END PRIVATE KEY-----

```



after compile pkey.lua to LuaJIT bytecode, like below
```
luajit -b ./resty/openssl/pkey.lua ./resty/openssl/pkey.ljbc
```

Then execution would failed
```
$ resty test.lua 
ERROR: ./resty/openssl/pkey.ljbc:0: wrong number of arguments for function call
stack traceback:
	./resty/openssl/pkey.ljbc: in function ''
	./resty/openssl/pkey.ljbc: in function 'new'
	test.lua:37: in function 'file_gen'
	init_worker_by_lua(nginx.conf:136):45: in function <init_worker_by_lua(nginx.conf:136):43>
	[C]: in function 'xpcall'
	init_worker_by_lua(nginx.conf:136):52: in function <init_worker_by_lua(nginx.conf:136):50>

```



