### PR TITLE
iv should be optional in cipher.init()

### DIFF
--- a/lib/resty/openssl/cipher.lua
+++ b/lib/resty/openssl/cipher.lua
@@ -100,7 +100,7 @@ function _M:init(key, iv, opts)
   if not key or #key ~= self.key_size then
     return false, string.format("cipher:init: incorrect key size, expect %d", self.key_size)
   end
-  if not iv or #iv ~= self.iv_size then
+  if iv and #iv ~= self.iv_size then
     return false, string.format("cipher:init: incorrect iv size, expect %d", self.iv_size)
   end
 

--- a/lib/resty/openssl/cipher.lua
+++ b/lib/resty/openssl/cipher.lua
@@ -100,7 +100,7 @@ function _M:init(key, iv, opts)
   if not key or #key ~= self.key_size then
     return false, string.format("cipher:init: incorrect key size, expect %d", self.key_size)
   end
-  if iv_size > 0 and (not iv or #iv ~= self.iv_size) then
+  if self.iv_size > 0 and (not iv or #iv ~= self.iv_size) then
     return false, string.format("cipher:init: incorrect iv size, expect %d", self.iv_size)
   end
 

--- a/lib/resty/openssl/cipher.lua
+++ b/lib/resty/openssl/cipher.lua
@@ -100,7 +100,7 @@ function _M:init(key, iv, opts)
   if not key or #key ~= self.key_size then
     return false, string.format("cipher:init: incorrect key size, expect %d", self.key_size)
   end
-  if iv and #iv ~= self.iv_size then
+  if iv_size > 0 and (not iv or #iv ~= self.iv_size) then
     return false, string.format("cipher:init: incorrect iv size, expect %d", self.iv_size)
   end
 


### PR DESCRIPTION
Though the purpose of an IV is to generate different cipher texts for same plaintext, one may not need the IV if every plaintext is different because of the business need. 

For example, in AES key wrapping, while an initialization vector (IV) is often used, it's not always mandatory. AES Key Wrap algorithm (RFC 3394) allows for an optional IV, using a default value if none is provided.