### PR TITLE
feat: fix table.unpack nil handling issue specific to LuaJIT bytecode…

### DIFF
--- a/lib/resty/openssl/kdf.lua
+++ b/lib/resty/openssl/kdf.lua
@@ -140,7 +140,7 @@ function _M.derive(options)
   end
 
   for k, v in pairs(options_schema) do
-    # don't use unpack here to avoid nil truncation
+    -- don't use unpack here to avoid nil truncation
     local v, err = check_options(options, typ, k, v[1],v[2],v[3])
     if err then
       return nil, "kdf.derive: " .. err


### PR DESCRIPTION

feat: fix table.unpack nil handling issue specific to LuaJIT bytecode compilation

Problem: table.unpack behaves differently in LuaJIT bytecode-compiled mode (ljbc)  vs standard Lua interpretation. Tables containing nil values cause argument  truncation only in ljbc mode due to different internal handling of array length.